### PR TITLE
Copy Angular API list JSON into build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "postinstall": "opencollective-postinstall || exit 0",
         "*********BUILD********": "*******************",
         "prebuild": "rimraf dist/*",
-        "build": "rollup -c rollup/rollup.config.mjs --bundleConfigAsCjs && npm run build-schematics",
+        "build": "rollup -c rollup/rollup.config.mjs --bundleConfigAsCjs && npm run build-schematics && node tools/copy-api-list.js",
         "build-schematics": "tsc --project schematics/tsconfig.json && cp schematics/collection.json dist",
         "*********UTILS********": "*******************",
         "changelog": "auto-changelog -o CH.md  --template tools/changelog-template.hbs -u",

--- a/tools/copy-api-list.js
+++ b/tools/copy-api-list.js
@@ -1,0 +1,4 @@
+const fs = require('fs-extra');
+
+fs.copySync('src/data/api-list.json', 'dist/src/data/api-list.json');
+


### PR DESCRIPTION
## Summary
- ensure Angular API list is bundled by copying `src/data/api-list.json` into the built distribution

## Testing
- `npm test` *(terminated: partial output available)*

------
https://chatgpt.com/codex/tasks/task_e_68b032f8f72c8331a39d7ed92051735d